### PR TITLE
Add simple settings menu and config save

### DIFF
--- a/Kernel.mk
+++ b/Kernel.mk
@@ -15,9 +15,10 @@ OBJS		:=	src/config.o \
 			src/lcd/drivers/hd44780fourbit.o \
 			src/lcd/drivers/hd44780i2c.o \
 			src/lcd/drivers/sh1106.o \
-			src/lcd/drivers/ssd1306.o \
-			src/lcd/ui.o \
-			src/main.o \
+                        src/lcd/drivers/ssd1306.o \
+                        src/lcd/ui.o \
+                        src/lcd/menu.o \
+                        src/main.o \
 			src/midimonitor.o \
 			src/midiparser.o \
 			src/mt32pi.o \

--- a/include/config.h
+++ b/include/config.h
@@ -76,8 +76,9 @@ public:
 	CONFIG_ENUM(TLCDType, ENUM_LCDTYPE);
 	CONFIG_ENUM(TNetworkMode, ENUM_NETWORKMODE);
 
-	CConfig();
-	bool Initialize(const char* pPath);
+        CConfig();
+        bool Initialize(const char* pPath);
+        bool Save(const char* pPath) const;
 
 	static CConfig* Get() { return s_pThis; }
 

--- a/include/lcd/menu.h
+++ b/include/lcd/menu.h
@@ -1,0 +1,42 @@
+//
+// menu.h
+//
+// Simple settings menu for mt32-pi
+//
+
+#ifndef _menu_h
+#define _menu_h
+
+#include "config.h"
+
+class CLCD;
+class CUserInterface;
+
+class CSettingsMenu
+{
+public:
+        enum class TItem
+        {
+                Verbose,
+                Visualization,
+                SaveExit,
+                Count
+        };
+
+        CSettingsMenu(CConfig& Config, CUserInterface& UI);
+
+        void ToggleActive();
+        bool IsActive() const { return m_bActive; }
+        void Next();
+        void Prev();
+        void Adjust(int nDelta);
+        void Draw(CLCD& LCD) const;
+
+private:
+        CConfig& m_Config;
+        CUserInterface& m_UI;
+        TItem m_CurrentItem;
+        bool m_bActive;
+};
+
+#endif

--- a/include/lcd/ui.h
+++ b/include/lcd/ui.h
@@ -29,6 +29,7 @@
 #include "lcd/lcd.h"
 
 class CSynthBase;
+class CSettingsMenu;
 
 class CUserInterface
 {
@@ -37,24 +38,35 @@ public:
 	{
 		Roland,
 		Yamaha,
-	};
+        }; 
 
-	CUserInterface();
+        enum class TVisualizationMode
+        {
+                ChannelLevels,
+                CPULoad,
+        };
 
-	void Update(CLCD& LCD, CSynthBase& Synth, unsigned int nTicks);
+        CUserInterface();
+
+        void Update(CLCD& LCD, CSynthBase& Synth, unsigned int nTicks);
 
 	void ShowSystemMessage(const char* pMessage, bool bSpinner = false);
 	void ClearSpinnerMessage();
 	void DisplayImage(TImage Image);
 	void ShowSysExText(TSysExDisplayMessage Type, const u8* pMessage, size_t nSize, u8 nOffset);
 	void ShowSysExBitmap(TSysExDisplayMessage Type, const u8* pData, size_t nSize);
-	void EnterPowerSavingMode();
-	void ExitPowerSavingMode();
+        void EnterPowerSavingMode();
+        void ExitPowerSavingMode();
 
-	bool IsScrolling() const { return m_bIsScrolling; }
+        bool IsScrolling() const { return m_bIsScrolling; }
 
-	static u8 CenterMessageOffset(CLCD& LCD, const char* pMessage);
-	static void DrawChannelLevels(CLCD& LCD, u8 nBarHeight, float* pChannelLevels, float* pPeakLevels, u8 nChannels, bool bDrawBarBases);
+        void AttachMenu(const CSettingsMenu* pMenu) { m_pMenu = pMenu; }
+        void SetVisualizationMode(TVisualizationMode Mode) { m_VisualizationMode = Mode; }
+        TVisualizationMode GetVisualizationMode() const { return m_VisualizationMode; }
+
+        static u8 CenterMessageOffset(CLCD& LCD, const char* pMessage);
+        static void DrawChannelLevels(CLCD& LCD, u8 nBarHeight, float* pChannelLevels, float* pPeakLevels, u8 nChannels, bool bDrawBarBases);
+        void DrawCPULoad(CLCD& LCD, unsigned int nTicks) const;
 
 private:
 	enum class TState
@@ -79,7 +91,7 @@ private:
 
 	static constexpr size_t SystemMessageTextBufferSize = 256;
 	static constexpr size_t SyxExTextBufferSize = 32 + 1;
-	static constexpr size_t SysExPixelBufferSize = 64;
+        static constexpr size_t SysExPixelBufferSize = 64;
 
 	static constexpr unsigned SystemMessageDisplayTimeMillis = 3000;
 	static constexpr unsigned SystemMessageSpinnerTimeMillis = 32;
@@ -95,7 +107,9 @@ private:
 	char m_SystemMessageTextBuffer[SystemMessageTextBufferSize];
 	TSysExDisplayMessage m_SysExDisplayMessageType;
 	char m_SysExTextBuffer[SyxExTextBufferSize];
-	u8 m_SysExPixelBuffer[SysExPixelBufferSize];
+        u8 m_SysExPixelBuffer[SysExPixelBufferSize];
+        const CSettingsMenu* m_pMenu;
+        TVisualizationMode m_VisualizationMode;
 };
 
 #endif

--- a/include/mt32pi.h
+++ b/include/mt32pi.h
@@ -52,6 +52,7 @@
 #include "control/mister.h"
 #include "event.h"
 #include "lcd/ui.h"
+#include "lcd/menu.h"
 #include "midiparser.h"
 #include "net/applemidi.h"
 #include "net/ftpdaemon.h"
@@ -166,11 +167,12 @@ private:
 
 	CBcmRandomNumberGenerator m_Random;
 
-	CLCD* m_pLCD;
-	unsigned m_nLCDUpdateTime;
-	CUserInterface m_UserInterface;
+        CLCD* m_pLCD;
+        unsigned m_nLCDUpdateTime;
+        CUserInterface m_UserInterface;
+        CSettingsMenu m_SettingsMenu;
 #ifdef MONITOR_TEMPERATURE
-	unsigned m_nTempUpdateTime;
+        unsigned m_nTempUpdateTime;
 #endif
 
 	CControl* m_pControl;

--- a/src/lcd/menu.cpp
+++ b/src/lcd/menu.cpp
@@ -1,0 +1,101 @@
+//
+// menu.cpp
+//
+// Simple settings menu implementation
+//
+
+#include <cstdio>
+
+#include "lcd/menu.h"
+#include "lcd/ui.h"
+#include "lcd/lcd.h"
+
+CSettingsMenu::CSettingsMenu(CConfig& Config, CUserInterface& UI)
+        : m_Config(Config),
+          m_UI(UI),
+          m_CurrentItem(TItem::Verbose),
+          m_bActive(false)
+{
+}
+
+void CSettingsMenu::ToggleActive()
+{
+        m_bActive = !m_bActive;
+        if (!m_bActive)
+                m_Config.Save("mt32-pi.cfg");
+        else
+                m_CurrentItem = TItem::Verbose;
+}
+
+void CSettingsMenu::Next()
+{
+        if (!m_bActive)
+                return;
+        m_CurrentItem = static_cast<TItem>((static_cast<int>(m_CurrentItem) + 1) % static_cast<int>(TItem::Count));
+}
+
+void CSettingsMenu::Prev()
+{
+        if (!m_bActive)
+                return;
+        m_CurrentItem = static_cast<TItem>((static_cast<int>(m_CurrentItem) + static_cast<int>(TItem::Count) - 1) % static_cast<int>(TItem::Count));
+}
+
+void CSettingsMenu::Adjust(int nDelta)
+{
+        if (!m_bActive || nDelta == 0)
+                return;
+
+        switch (m_CurrentItem)
+        {
+                case TItem::Verbose:
+                        m_Config.SystemVerbose = !m_Config.SystemVerbose;
+                        break;
+
+                case TItem::Visualization:
+                {
+                        auto Mode = m_UI.GetVisualizationMode();
+                        m_UI.SetVisualizationMode(Mode == CUserInterface::TVisualizationMode::ChannelLevels ?
+                                                   CUserInterface::TVisualizationMode::CPULoad :
+                                                   CUserInterface::TVisualizationMode::ChannelLevels);
+                        break;
+                }
+
+                case TItem::SaveExit:
+                        m_Config.Save("mt32-pi.cfg");
+                        m_bActive = false;
+                        break;
+
+                case TItem::Count:
+                        break;
+        }
+}
+
+void CSettingsMenu::Draw(CLCD& LCD) const
+{
+        if (!m_bActive)
+                return;
+
+        char Buffer[32];
+        switch (m_CurrentItem)
+        {
+                case TItem::Verbose:
+                        snprintf(Buffer, sizeof(Buffer), "Verbose: %s", m_Config.SystemVerbose ? "on" : "off");
+                        break;
+
+                case TItem::Visualization:
+                        snprintf(Buffer, sizeof(Buffer), "Viz: %s", m_UI.GetVisualizationMode() == CUserInterface::TVisualizationMode::ChannelLevels ? "levels" : "cpu");
+                        break;
+
+                case TItem::SaveExit:
+                        snprintf(Buffer, sizeof(Buffer), "Save & exit");
+                        break;
+
+                case TItem::Count:
+                        Buffer[0] = '\0';
+                        break;
+        }
+
+        LCD.Print(Buffer, 0, 0, true, false);
+}
+


### PR DESCRIPTION
## Summary
- add `CConfig::Save` to persist configuration back to disk
- introduce `CSettingsMenu` allowing on-device menu navigation and visualization mode toggle
- extend LCD UI with menu support and optional CPU load visualization

## Testing
- `make submodules` *(fails: unable to access remote repositories, 403)*

------
https://chatgpt.com/codex/tasks/task_e_688d8323b690832386df6d1313baee87