### PR TITLE
Only save config when selecting Save & exit

### DIFF
--- a/src/lcd/menu.cpp
+++ b/src/lcd/menu.cpp
@@ -21,9 +21,7 @@ CSettingsMenu::CSettingsMenu(CConfig& Config, CUserInterface& UI)
 void CSettingsMenu::ToggleActive()
 {
         m_bActive = !m_bActive;
-        if (!m_bActive)
-                m_Config.Save("mt32-pi.cfg");
-        else
+        if (m_bActive)
                 m_CurrentItem = TItem::Verbose;
 }
 


### PR DESCRIPTION
## Summary
- prevent the settings menu from writing the configuration file when exiting via a mode toggle
- keep the "Save & exit" menu item responsible for persisting changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f73d80735c8323a47a6ecaf387f197